### PR TITLE
[FEAT] 권한 인가 필터 구현 

### DIFF
--- a/src/main/java/com/sparta/outsourcing/common/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/outsourcing/common/exception/ErrorCode.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 @Getter
 public enum ErrorCode {
 
-    STORE_NOT_FOUND(404,"해당 가게가 없습니다."),
+    STORE_NOT_FOUND(404, "해당 가게가 없습니다."),
 
     USER_NOT_FOUND(404, "해당 유저가 없습니다."),
     ALREADY_USER_EXIST(400, "존재하는 유저입니다."),
@@ -13,6 +13,9 @@ public enum ErrorCode {
 
     TOO_MANY_STORES(409, "이미 3개의 가게를 가지고 있습니다."),
     ALREADY_STORE_EXIST(409, "같은 상호명의 가게가 이미 존재합니다."),
+    INVALID_TOKEN_ERROR(401, "잘못된 토큰 정보입니다."),
+    TOKEN_NOT_FOUND(401, "토큰 정보를 찾을 수 없습니다."),
+    AUTHORITY_NOT_FOUND(403, "권한 정보를 찾을 수 없습니다."),
     ;
 
     private final int status;

--- a/src/main/java/com/sparta/outsourcing/common/security/JwtProvider.java
+++ b/src/main/java/com/sparta/outsourcing/common/security/JwtProvider.java
@@ -1,16 +1,20 @@
 package com.sparta.outsourcing.common.security;
 
+import com.sparta.outsourcing.common.exception.CustomApiException;
+import com.sparta.outsourcing.common.exception.ErrorCode;
+import com.sparta.outsourcing.domain.user.entity.User;
+import com.sparta.outsourcing.domain.user.entity.UserRole;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
-import java.util.Base64;
-import java.util.Date;
+import java.util.*;
 
 @Slf4j
 @Component
@@ -32,29 +36,44 @@ public class JwtProvider {
         key = Keys.hmacShaKeyFor(decode);
     }
 
-    public String generateToken(Authentication authentication) {
+    public String generateToken(LoginUser loginUser) {
         Date now = new Date();
         return TOKEN_PREFIX + Jwts.builder()
-                .setSubject(authentication.getName())
-                .claim(AUTHORIZATION_KEY, authentication.getAuthorities().iterator().next())
+                .setSubject(loginUser.getUsername())
+                .claim("id", loginUser.getUser().getUserId())
+                .claim(AUTHORIZATION_KEY, loginUser.getAuthorities().iterator().next())
                 .setExpiration(new Date(now.getTime() + EXPIRATION_TIME))
                 .signWith(key, signatureAlgorithm)
                 .compact();
     }
 
-    public boolean validateToken(String token) {
+    public LoginUser validateToken(String token) {
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-            return true;
+
+            Jws<Claims> claims = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+
+            Object id =  claims.getBody().get("id");
+            String email = claims.getBody().getSubject();
+            String role = (String) ((Map<String, Object>) claims.getBody().get("auth")).get("authority");
+            log.info("role = {}" , role);
+
+            return new LoginUser(User.builder().userId(((Number) id).longValue()).email(email).role(UserRole.fromAuthority(role)).build());
         } catch (SecurityException | MalformedJwtException e) {
             log.info("Invalid JWT signature, 유효하지 않는 JWT 서명입니다. ");
+            throw new CustomApiException(ErrorCode.INVALID_TOKEN_ERROR);
         } catch (ExpiredJwtException e) {
             log.info("Expired JWT token, 만료된 JWT token 입니다.");
+            throw new CustomApiException(ErrorCode.INVALID_TOKEN_ERROR);
         } catch (UnsupportedJwtException e) {
             log.info("Unsupported JWT token, 지원되지 않는 JWT 토큰입니다.");
+            throw new CustomApiException(ErrorCode.INVALID_TOKEN_ERROR);
         } catch (IllegalArgumentException e) {
             log.info("JWT claims is empty, 잘못된 JWT 토큰입니다. ");
+            throw new CustomApiException(ErrorCode.INVALID_TOKEN_ERROR);
         }
-        return false;
     }
 }

--- a/src/main/java/com/sparta/outsourcing/common/security/LoginUser.java
+++ b/src/main/java/com/sparta/outsourcing/common/security/LoginUser.java
@@ -41,7 +41,7 @@ public class LoginUser implements UserDetails {
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         Collection<GrantedAuthority> authorities = new ArrayList<>();
-        authorities.add(() -> "ROLE_" + user.getRole());
+        authorities.add(() -> user.getRole().getAuthority());
         return authorities;
     }
 

--- a/src/main/java/com/sparta/outsourcing/common/security/filter/CustomAuthorizationFilter.java
+++ b/src/main/java/com/sparta/outsourcing/common/security/filter/CustomAuthorizationFilter.java
@@ -1,0 +1,53 @@
+package com.sparta.outsourcing.common.security.filter;
+
+import com.sparta.outsourcing.common.exception.CustomApiException;
+import com.sparta.outsourcing.common.exception.ErrorCode;
+import com.sparta.outsourcing.common.security.JwtProvider;
+import com.sparta.outsourcing.common.security.LoginUser;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+import java.io.IOException;
+
+@Slf4j
+public class CustomAuthorizationFilter extends BasicAuthenticationFilter {
+
+    private final JwtProvider jwtProvider;
+
+    public CustomAuthorizationFilter(AuthenticationManager authenticationManager, JwtProvider jwtProvider) {
+        super(authenticationManager);
+        this.jwtProvider = jwtProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String requestURI = request.getRequestURI();
+        if(requestURI.contains("/auth/join") || requestURI.contains("/auth/sign")){
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String header = request.getHeader("Authorization");
+        if(header == null || !header.startsWith("Bearer ")){
+            throw new CustomApiException(ErrorCode.TOKEN_NOT_FOUND);
+        }
+
+        String token = header.replace("Bearer ", "");
+        log.info("token 정보 추출 = {} ", token);
+
+        LoginUser loginUser = jwtProvider.validateToken(token);
+        log.info("토큰 정보 검증 후 토큰 정보에서 User 정보 추출 = {}", loginUser.getUser().getEmail());
+
+        UsernamePasswordAuthenticationToken authenticationToken
+                = new UsernamePasswordAuthenticationToken(loginUser, null, loginUser.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/sparta/outsourcing/common/security/filter/CustomUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/com/sparta/outsourcing/common/security/filter/CustomUsernamePasswordAuthenticationFilter.java
@@ -52,7 +52,7 @@ public class CustomUsernamePasswordAuthenticationFilter extends UsernamePassword
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
         ObjectMapper mapper = new ObjectMapper();
         SecurityContextHolder.getContext().setAuthentication(authResult);
-        String token = jwtProvider.generateToken(authResult);
+        String token = jwtProvider.generateToken((LoginUser) authResult.getPrincipal());
 
         response.addHeader("Authorization", token);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/com/sparta/outsourcing/common/security/filter/GlobalFilterExceptionHandler.java
+++ b/src/main/java/com/sparta/outsourcing/common/security/filter/GlobalFilterExceptionHandler.java
@@ -6,6 +6,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.MediaType;
 import org.springframework.web.filter.OncePerRequestFilter;
 

--- a/src/main/java/com/sparta/outsourcing/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/outsourcing/config/SecurityConfig.java
@@ -1,7 +1,7 @@
 package com.sparta.outsourcing.config;
 
-import com.sparta.outsourcing.common.security.CustomAuthenticationProvider;
 import com.sparta.outsourcing.common.security.JwtProvider;
+import com.sparta.outsourcing.common.security.filter.CustomAuthorizationFilter;
 import com.sparta.outsourcing.common.security.filter.CustomUsernamePasswordAuthenticationFilter;
 import com.sparta.outsourcing.common.security.filter.GlobalFilterExceptionHandler;
 import lombok.RequiredArgsConstructor;
@@ -10,10 +10,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.AuthenticationProvider;
-import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
-import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -21,7 +17,6 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.web.DefaultSecurityFilterChain;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -60,9 +55,13 @@ public class SecurityConfig {
                 )
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
-                .addFilterBefore(new GlobalFilterExceptionHandler(), UsernamePasswordAuthenticationFilter.class)
-                .addFilter(new CustomUsernamePasswordAuthenticationFilter(authenticationManager(authenticationConfiguration), jwtProvider))
                 .anonymous(AbstractHttpConfigurer::disable)
+                .addFilterBefore(new GlobalFilterExceptionHandler(),
+                        CustomAuthorizationFilter.class)
+                .addFilterBefore(new CustomAuthorizationFilter(authenticationManager(authenticationConfiguration), jwtProvider),
+                        CustomUsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new CustomUsernamePasswordAuthenticationFilter(authenticationManager(authenticationConfiguration), jwtProvider),
+                        UsernamePasswordAuthenticationFilter.class)
         ;
 
         log.info("Security Filter Chain Test 버전 빈 등록");

--- a/src/main/java/com/sparta/outsourcing/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/outsourcing/config/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
 
 
     @Bean
-    @Profile("test1")
+    @Profile("security")
     public SecurityFilterChain securityFilterChainTest(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
@@ -55,8 +55,11 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/join").permitAll()
                         .requestMatchers("/auth/sign").permitAll()
+                        .requestMatchers("/error").permitAll()
                         .anyRequest().authenticated()
                 )
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
                 .addFilterBefore(new GlobalFilterExceptionHandler(), UsernamePasswordAuthenticationFilter.class)
                 .addFilter(new CustomUsernamePasswordAuthenticationFilter(authenticationManager(authenticationConfiguration), jwtProvider))
                 .anonymous(AbstractHttpConfigurer::disable)

--- a/src/main/java/com/sparta/outsourcing/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/controller/UserController.java
@@ -1,12 +1,16 @@
 package com.sparta.outsourcing.domain.user.controller;
 
 import com.sparta.outsourcing.domain.user.dto.request.UserCreateReqDto;
+import com.sparta.outsourcing.domain.user.dto.request.UserDeleteReqDto;
 import com.sparta.outsourcing.domain.user.dto.response.UserCreateRespDto;
+import com.sparta.outsourcing.domain.user.dto.response.UserDeleteRespDto;
 import com.sparta.outsourcing.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,4 +26,12 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.CREATED).body(userService.register(dto));
     }
 
+    @DeleteMapping("/auth/users")
+    public ResponseEntity<UserDeleteRespDto> deleteCurrentUser(
+            @AuthenticationPrincipal LogignUser logignUser,
+            @RequestBody @Valid UserDeleteReqDto reqDto
+    ) {
+        UserDeleteRespDto respDto = userService.deleteUser(loginUser.getUserId(), reqDto);
+        return ResponseEntity.status(HttpStatus.OK).body(respDto);
+    }
 }

--- a/src/main/java/com/sparta/outsourcing/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/controller/UserController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/com/sparta/outsourcing/domain/user/dto/request/UserDeleteReqDto.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/dto/request/UserDeleteReqDto.java
@@ -1,0 +1,13 @@
+package com.sparta.outsourcing.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserDeleteReqDto {
+
+    @NotBlank(message = "패스워드를 입력해주세요.")
+    private String password;
+}

--- a/src/main/java/com/sparta/outsourcing/domain/user/dto/response/UserDeleteRespDto.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/dto/response/UserDeleteRespDto.java
@@ -1,0 +1,14 @@
+package com.sparta.outsourcing.domain.user.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserDeleteRespDto {
+    private Long userId;
+
+    public UserDeleteRespDto(Long userId) {
+        this.userId = userId;
+    }
+}

--- a/src/main/java/com/sparta/outsourcing/domain/user/dto/response/UserDeleteRespDto.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/dto/response/UserDeleteRespDto.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
 public class UserDeleteRespDto {
     private Long userId;
 

--- a/src/main/java/com/sparta/outsourcing/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/entity/User.java
@@ -7,11 +7,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "users")
+@SQLDelete(sql = "update users set deleted = true where user_id = ?")
 public class User extends BaseEntity {
 
     @Id
@@ -29,6 +31,8 @@ public class User extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private UserRole role;
+
+    private boolean deleted = Boolean.FALSE;
 
     @Builder
     public User(String email, String password, String nickname, UserRole role) {

--- a/src/main/java/com/sparta/outsourcing/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/entity/User.java
@@ -35,7 +35,8 @@ public class User extends BaseEntity {
     private boolean deleted = Boolean.FALSE;
 
     @Builder
-    public User(String email, String password, String nickname, UserRole role) {
+    public User(Long userId, String email, String password, String nickname, UserRole role) {
+        this.userId = userId;
         this.email = email;
         this.password = password;
         this.nickname = nickname;

--- a/src/main/java/com/sparta/outsourcing/domain/user/entity/UserRole.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/entity/UserRole.java
@@ -1,6 +1,15 @@
 package com.sparta.outsourcing.domain.user.entity;
 
-public enum UserRole {
-    USER, OWNER
+import lombok.Getter;
 
+@Getter
+public enum UserRole {
+    USER("ROLE_USER"),
+    OWNER("ROLE_OWNER");
+
+    private String authority;
+
+    UserRole(String authority) {
+        this.authority = authority;
+    }
 }

--- a/src/main/java/com/sparta/outsourcing/domain/user/entity/UserRole.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/entity/UserRole.java
@@ -1,5 +1,7 @@
 package com.sparta.outsourcing.domain.user.entity;
 
+import com.sparta.outsourcing.common.exception.CustomApiException;
+import com.sparta.outsourcing.common.exception.ErrorCode;
 import lombok.Getter;
 
 @Getter
@@ -11,5 +13,14 @@ public enum UserRole {
 
     UserRole(String authority) {
         this.authority = authority;
+    }
+
+    public static UserRole fromAuthority(String authority) {
+        for (UserRole value : values()) {
+            if (value.getAuthority().equals(authority)) {
+                return value;
+            }
+        }
+        throw new CustomApiException(ErrorCode.AUTHORITY_NOT_FOUND);
     }
 }

--- a/src/main/java/com/sparta/outsourcing/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/service/UserService.java
@@ -3,9 +3,13 @@ package com.sparta.outsourcing.domain.user.service;
 import com.sparta.outsourcing.common.exception.CustomApiException;
 import com.sparta.outsourcing.common.exception.ErrorCode;
 import com.sparta.outsourcing.domain.user.dto.request.UserCreateReqDto;
+import com.sparta.outsourcing.domain.user.dto.request.UserDeleteReqDto;
 import com.sparta.outsourcing.domain.user.dto.response.UserCreateRespDto;
+import com.sparta.outsourcing.domain.user.dto.response.UserDeleteRespDto;
+import com.sparta.outsourcing.domain.user.entity.User;
 import com.sparta.outsourcing.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -18,9 +22,25 @@ public class UserService {
 
     public UserCreateRespDto register(UserCreateReqDto dto) {
         userRepository.findByEmail(dto.getEmail())
-                .ifPresent(user -> {throw new CustomApiException(ErrorCode.ALREADY_USER_EXIST);});
+                .ifPresent(user -> {
+                    throw new CustomApiException(ErrorCode.ALREADY_USER_EXIST);
+                });
         dto.setPassword(passwordEncoder.encode(dto.getPassword()));
         return new UserCreateRespDto(userRepository.save(dto.toEntity()).getUserId());
+    }
+
+    public UserDeleteRespDto deleteUser(Long userId, UserDeleteReqDto dto) {
+        User findUser = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomApiException(ErrorCode.USER_NOT_FOUND));
+
+        if (!passwordEncoder.matches(dto.getPassword(), findUser.getPassword())) {
+            throw new CustomApiException(ErrorCode.MiSS_MATCH_PASSWORD);
+        }
+
+        userRepository.delete(findUser);
+        SecurityContextHolder.clearContext();
+
+        return new UserDeleteRespDto(findUser.getUserId());
     }
 
 }

--- a/src/main/java/com/sparta/outsourcing/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/outsourcing/domain/user/service/UserService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +30,7 @@ public class UserService {
         return new UserCreateRespDto(userRepository.save(dto.toEntity()).getUserId());
     }
 
+    @Transactional
     public UserDeleteRespDto deleteUser(Long userId, UserDeleteReqDto dto) {
         User findUser = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomApiException(ErrorCode.USER_NOT_FOUND));

--- a/src/main/resources/application-security.yml
+++ b/src/main/resources/application-security.yml
@@ -1,0 +1,33 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test;MODE=MySQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  h2:
+    console:
+      enabled: true
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: update
+    properties:
+      '[hibernate.default_batch_fetch_size]': 100
+      '[hibernate.format_sql]': true
+    show-sql: true
+  output:
+    ansi:
+      enabled: always
+
+jwt:
+  secret:
+    key: XyZ1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p7q8r9s0t1u2v3w4x5y6z7A8B9C0D1
+
+logging:
+  level:
+    org.springframework.security: DEBUG
+    org.springframework.security.web.FilterChainProxy: DEBUG
+    org.springframework.security.web.access: DEBUG
+    org.springframework.security.authentication: DEBUG
+    org.springframework.security.authorization: DEBUG


### PR DESCRIPTION
## 이슈 : #32 

1. 권한 인가 필터 추가하여 @AuthenticationPrincipal 또는 Authentication 에서 LoginUser 를 통해 인증 정보를 가져올 수 있습니다. 
2. application-security.yml 을 추가하여 추후 시큐리티와 통합테스트를 진행하고 싶은신 분은 application.yml 에서 `dev` -> `security` 로 변경하시면 됩니다. 
3. 테스트 용 json 값 남겨놓을께요!! 

회원가입 RequestBody 
```
{
    "email" : "asdf@naver.com",
    "password" : "password1!",
    "nickname" : "user1",
    "role" : "USER"
    "phoneNumber" : "010-0000-0000",
    "address" : {
        "street" : "APT",
        "details" : "100/100",
        "postCode" : "111-111"
    }
}
```

로그인 RequestBody 
```
{
    "email" : "asdf@naver.com",
    "password" : "password1!"
}
```

- 로그인 성공 후에는 토큰 정보가 넘어오게 됩니다. 다른 API 호출시 토큰 정보를 Header에 넣어줘어야 정상적으로 동작합니다. 